### PR TITLE
Automatically generate local directory name from repository URL

### DIFF
--- a/src/main/java/elegit/ClonedRepoHelperBuilder.java
+++ b/src/main/java/elegit/ClonedRepoHelperBuilder.java
@@ -141,6 +141,12 @@ public class ClonedRepoHelperBuilder extends RepoHelperBuilder {
 
         repoNameField = new TextField();
         repoNameField.setPromptText("Repository name...");
+        remoteURLField.textProperty().addListener((obs, oldText, newText) -> {
+            if (newText.endsWith(".git")) {
+                String[] urlComponents = newText.substring(0, newText.length() - 4).split("/");
+                repoNameField.setText(urlComponents[urlComponents.length - 1]);
+            }
+        });
         if(prevRepoName != null) repoNameField.setText(prevRepoName);
 
         int instructionsRow = 0;


### PR DESCRIPTION
This implements automatic repository name generation in #467. When the user enters a remote repository URL, the "Repository name" field will be automatically populated with the last portion of the URL.

For instance, `https://github.com/dmusican/Elegit.git` will result in the repository name field being set to "Elegit".

This should probably be split out into its own method and properly unit-tested before being merged into master, but the underlying logic is up and running.