### PR TITLE
fixed typo in repository drop down: "commmit"

### DIFF
--- a/src/main/resources/elegit/fxml/MainViewMenu.fxml
+++ b/src/main/resources/elegit/fxml/MainViewMenu.fxml
@@ -60,7 +60,7 @@
                                 fx:id="cloneMenuItem"
                                 onAction="#handleCloneNewRepoOption"/>
                 </Menu>
-                <Menu   text="Commmit">
+                <Menu   text="Commit">
                     <MenuItem   text="Commit"
                                 fx:id="commitNormalMenuItem"
                                 onAction="#handleCommitNormal"/>


### PR DESCRIPTION
Literally the only thing I did was get rid of the extra m in "commmit" in the repository drop down menu.