### PR TITLE
Fixed #500 and added some styling to the busywindow

### DIFF
--- a/src/main/java/elegit/BusyWindow.java
+++ b/src/main/java/elegit/BusyWindow.java
@@ -1,18 +1,18 @@
 package elegit;
 
 import javafx.application.Platform;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderStroke;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
-import javafx.stage.Modality;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
-import javafx.stage.Window;
+import javafx.stage.*;
 
 /**
  * Created by makik on 7/8/15.
@@ -50,15 +50,35 @@ public class BusyWindow{
         VBox parent = new VBox(img, loadingMessage);
         parent.setSpacing(20);
         parent.setAlignment(Pos.CENTER);
+        parent.setStyle("-fx-border-color: #000000;\n -fx-padding: 10 10 10 10");
         return parent;
     }
 
     public static void setParentWindow(Window parent){
         window.initOwner(parent);
+        window.setX(parent.getX()+parent.getWidth()/2-window.getWidth()/2);
+        window.setY(parent.getY()+parent.getHeight()/2-window.getHeight()/2);
     }
 
     public static void show(){
-        if(numProcessesActive == 0) Platform.runLater(window::show);
+        if(numProcessesActive == 0) {
+            Platform.runLater(() -> {
+                Window parent = window.getOwner();
+                double windowWidth, windowHeight;
+                // If window hasn't been shown before, getWidth() will be NaN
+                // so we have to have a default
+                if (window.getWidth()>0) {
+                    windowWidth = window.getWidth();
+                    windowHeight = window.getHeight();
+                } else {
+                    windowWidth = 148;
+                    windowHeight = 82;
+                }
+                window.setX(parent.getX()+parent.getWidth()/2-windowWidth/2);
+                window.setY(parent.getY()+parent.getHeight()/2-windowHeight/2);
+                window.show();
+            });
+        }
         numProcessesActive++;
     }
 


### PR DESCRIPTION
Just made the busywindow show up in the center of the main window, wherever it is when show() is called. I figured moving it around with the window would be overkill, as it is rare for the window to persist for very long.