### PR TITLE
Fixed #509

### DIFF
--- a/src/main/java/elegit/BranchHelper.java
+++ b/src/main/java/elegit/BranchHelper.java
@@ -73,7 +73,7 @@ public abstract class BranchHelper extends RefHelper {
      * @return the id of this branch's head
      * @throws IOException
      */
-    ObjectId getHeadId() throws IOException{
+    public ObjectId getHeadId() throws IOException{
         if(commit != null){
             return commit.getObjectId();
         }else{

--- a/src/main/java/elegit/BranchModel.java
+++ b/src/main/java/elegit/BranchModel.java
@@ -452,6 +452,7 @@ public class BranchModel {
         return false;
     }
 
+    //todo
     /**
      * Updates the heads of all local and remote branches, then returns a map of them
      * @return

--- a/src/main/java/elegit/BranchModel.java
+++ b/src/main/java/elegit/BranchModel.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Model class that keeps track of all BranchModels for a RepoHelper
+ * Model class that keeps track of all BranchHelpers for a RepoHelper
  *
  * Also implements git stuff that concerns multiple branches
  *      -adding, removing

--- a/src/main/java/elegit/CommitTreeController.java
+++ b/src/main/java/elegit/CommitTreeController.java
@@ -249,6 +249,7 @@ public class CommitTreeController{
         }
     }
 
+    // todo use this
     /**
      * Loops through the branches and sets the cells that are branch heads to have the
      * correct shape (untracked=circle, tracked=traingle)

--- a/src/main/java/elegit/CommitTreeModel.java
+++ b/src/main/java/elegit/CommitTreeModel.java
@@ -633,8 +633,6 @@ public class CommitTreeModel{
         return this.view.getName();
     }
 
-
-
     public List<CommitHelper> getCommitsInModel() { return this.commitsInModel; }
 
     public List<BranchHelper> getBranchesInModel() { return this.branchesInModel; }

--- a/src/main/java/elegit/RepoHelper.java
+++ b/src/main/java/elegit/RepoHelper.java
@@ -584,7 +584,7 @@ public class RepoHelper {
      * Helper method that returns either the only remote, or the remote chosen by the user
      * @return String remote
      */
-    private String getRemote() {
+    public String getRemote() {
         Git git = new Git(this.repo);
         StoredConfig config = git.getRepository().getConfig();
         Set<String> remotes = config.getSubsections("remote");

--- a/src/main/java/elegit/SessionModel.java
+++ b/src/main/java/elegit/SessionModel.java
@@ -36,7 +36,7 @@ public class SessionModel {
     private static final String LAST_OPENED_REPO_PATH_KEY = "LAST_OPENED_REPO_PATH";
     private static final String LAST_UUID_KEY="LAST_UUID";
 
-    private RepoHelper currentRepoHelper;
+    public RepoHelper currentRepoHelper;
     ObjectProperty<RepoHelper> currentRepoHelperProperty;
 
     private List<RepoHelper> allRepoHelpers;
@@ -669,4 +669,10 @@ public class SessionModel {
     public String getLastUUID() throws BackingStoreException, ClassNotFoundException, IOException {
         return (String) PrefObj.getObject(this.preferences, LAST_UUID_KEY);
     }
+
+    public BranchHelper getCurrentBranch(){
+        return this.getCurrentRepoHelper().getBranchModel().getCurrentBranch();
+    }
+
+
 }

--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -306,7 +306,12 @@ public class SessionController {
         needToFetch.setFont(new Font(15));
         needToFetch.setFill(fetchColor);
 
+        // todo: bug with update here. should be name different or commit different
+        // but is this the best place to decide?
         BranchHelper localBranch = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentBranch();
+
+        //CommitHelper commit = localBranch.getCommit();
+
         update = !localBranch.getAbbrevName().equals(currentLocalBranchLabel.getText());
         if (update) {
             Platform.runLater(() -> {

--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -310,10 +310,6 @@ public class SessionController {
      * Helper method to update the text of local and remote branch labels
      */
     private void updateBranchLabels() {
-        // todo: Still need to fix errors with which branch labels are blue
-        // Also just found a bug, probably unrelated but
-        // it seems like git lets you checkout branches even if you get the capitalization wrong
-        // and Elegit doesn't support that and gets confused if you do so
 
         BranchHelper localBranch = theModel.getCurrentBranch();
         boolean update = !localBranch.getAbbrevName().equals(currentLocalBranchLabel.getText());
@@ -323,15 +319,15 @@ public class SessionController {
                 currentLocalBranchLabel.setText(localBranch.getAbbrevName());
                 currentLocalBranchLabel.setOnMouseClicked(event -> focusCommitLocalBranch());
                 addToolTip(currentLocalBranchHbox, localBranch.getRefName());
+                // makes sure correct label is highlighted in blue
+                CommitTreeController.setBranchHeads(commitTreeModel, theModel.getCurrentRepoHelper());
             });
         }
 
         String remoteBranch = "N/A";
         String remoteBranchFull = "N/A";
-        //CommitHelper remoteHead = null;
         try {
             remoteBranch = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteAbbrevBranch();
-            //remoteHead = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteBranchHead();
             remoteBranchFull = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteBranch();
         } catch (IOException e) {
             this.showGenericErrorNotification();
@@ -350,6 +346,8 @@ public class SessionController {
                 currentRemoteTrackingLabel.setText(remoteBranchFinal);
                 currentRemoteTrackingLabel.setOnMouseClicked(event -> focusCommitRemoteBranch());
                 addToolTip(currentRemoteTrackingBranchHbox, remoteBranchFullFinal);
+                // makes sure correct label is highlighted in blue
+                CommitTreeController.setBranchHeads(commitTreeModel, theModel.getCurrentRepoHelper());
             });
         }
     }

--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -317,9 +317,7 @@ public class SessionController {
         if (update) {
             Platform.runLater(() -> {
                 currentLocalBranchLabel.setText(localBranch.getAbbrevName());
-                currentLocalBranchLabel.setOnMouseClicked(event -> focusCommitLocalBranch());
                 addToolTip(currentLocalBranchHbox, localBranch.getRefName());
-                // makes sure correct label is highlighted in blue
                 CommitTreeController.setBranchHeads(commitTreeModel, theModel.getCurrentRepoHelper());
             });
         }
@@ -344,9 +342,7 @@ public class SessionController {
         if (update) {
             Platform.runLater(() -> {
                 currentRemoteTrackingLabel.setText(remoteBranchFinal);
-                currentRemoteTrackingLabel.setOnMouseClicked(event -> focusCommitRemoteBranch());
                 addToolTip(currentRemoteTrackingBranchHbox, remoteBranchFullFinal);
-                // makes sure correct label is highlighted in blue
                 CommitTreeController.setBranchHeads(commitTreeModel, theModel.getCurrentRepoHelper());
             });
         }

--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -310,6 +310,10 @@ public class SessionController {
      * Helper method to update the text of local and remote branch labels
      */
     private void updateBranchLabels() {
+        // todo: Still need to fix errors with which branch labels are blue
+        // Also just found a bug, probably unrelated but
+        // it seems like git lets you checkout branches even if you get the capitalization wrong
+        // and Elegit doesn't support that and gets confused if you do so
 
         BranchHelper localBranch = theModel.getCurrentBranch();
         boolean update = !localBranch.getAbbrevName().equals(currentLocalBranchLabel.getText());
@@ -317,16 +321,17 @@ public class SessionController {
         if (update) {
             Platform.runLater(() -> {
                 currentLocalBranchLabel.setText(localBranch.getAbbrevName());
+                currentLocalBranchLabel.setOnMouseClicked(event -> focusCommitLocalBranch());
                 addToolTip(currentLocalBranchHbox, localBranch.getRefName());
             });
         }
 
         String remoteBranch = "N/A";
         String remoteBranchFull = "N/A";
-        CommitHelper remoteHead = null;
+        //CommitHelper remoteHead = null;
         try {
             remoteBranch = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteAbbrevBranch();
-            remoteHead = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteBranchHead();
+            //remoteHead = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteBranchHead();
             remoteBranchFull = this.theModel.getCurrentRepoHelper().getBranchModel().getCurrentRemoteBranch();
         } catch (IOException e) {
             this.showGenericErrorNotification();
@@ -343,6 +348,7 @@ public class SessionController {
         if (update) {
             Platform.runLater(() -> {
                 currentRemoteTrackingLabel.setText(remoteBranchFinal);
+                currentRemoteTrackingLabel.setOnMouseClicked(event -> focusCommitRemoteBranch());
                 addToolTip(currentRemoteTrackingBranchHbox, remoteBranchFullFinal);
             });
         }

--- a/src/main/java/elegit/treefx/CellLabel.java
+++ b/src/main/java/elegit/treefx/CellLabel.java
@@ -134,6 +134,7 @@ public class CellLabel extends HBox {
         Tooltip.install(l, tooltip);
     }
 
+    // todo: use this to change fill based on if current or not
     /**
      * Sets the various items to have the current style
      * @param current whether or not this label is current


### PR DESCRIPTION
Local Branch and Remote-Tracking Branch labels above the index, the commit to focus in the graph, and which branch labels are blue are now updating correctly. In detached HEAD state, no branch labels are highlighted in blue and the buttons aren't clickable.