### PR TITLE
Ref label display

### DIFF
--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -163,6 +163,7 @@ public class SessionController {
 
     // Commit Info Box
     @FXML public CommitInfoController commitInfoController;
+    @FXML public VBox infoTagBox;
 
 
     boolean tryCommandAgainWithHTTPAuth;
@@ -2448,6 +2449,7 @@ public class SessionController {
 
             tagNameField.setVisible(true);
             tagButton.setVisible(true);
+            infoTagBox.toFront();
         });
     }
 
@@ -2457,11 +2459,13 @@ public class SessionController {
     public void clearSelectedCommit(){
         Platform.runLater(() -> {
             commitInfoController.clearCommit();
+            commitTreePanelView.toFront();
 
             tagNameField.setText("");
             tagNameField.setVisible(false);
             tagButton.setVisible(false);
             pushTagsButton.setVisible(false);
+            infoTagBox.toBack();
         });
     }
 

--- a/src/main/java/elegit/controllers/SessionController.java
+++ b/src/main/java/elegit/controllers/SessionController.java
@@ -1,7 +1,5 @@
 package elegit.controllers;
 
-import de.jensd.fx.glyphs.GlyphsDude;
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
 import elegit.*;
 import elegit.exceptions.*;
 import elegit.treefx.TreeLayout;
@@ -19,12 +17,8 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.*;
 import javafx.scene.control.Label;
-import javafx.scene.control.Menu;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.CheckMenuItem;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
-import javafx.scene.image.ImageView;
+import javafx.scene.image.*;
 import javafx.scene.input.*;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;

--- a/src/main/resources/elegit/fxml/CommitInfoView.fxml
+++ b/src/main/resources/elegit/fxml/CommitInfoView.fxml
@@ -8,8 +8,6 @@
 
 
 <VBox xmlns:fx="http://javafx.com/fxml"
-      GridPane.rowIndex="4"
-      GridPane.columnIndex="6"
       alignment="TOP_CENTER"
       spacing="5"
       fx:controller="elegit.controllers.CommitInfoController">

--- a/src/main/resources/elegit/fxml/MainView.fxml
+++ b/src/main/resources/elegit/fxml/MainView.fxml
@@ -240,8 +240,7 @@
                         GridPane.rowIndex="3"
                         GridPane.columnIndex="4">
                     <Text   text="Status: "/>
-                    <StackPane  fx:id="statusTextPane"
-                           alignment="CENTER">
+                    <StackPane  fx:id="statusTextPane">
                         <Text   fx:id="branchStatusText"/>
                     </StackPane>
                 </HBox>

--- a/src/main/resources/elegit/fxml/MainView.fxml
+++ b/src/main/resources/elegit/fxml/MainView.fxml
@@ -428,14 +428,15 @@
                     </VBox>
                 </StackPane>
 
-                <fx:include source="CommitInfoView.fxml" fx:id="commitInfo"/>
-
-                <!-- Tagging UI -->
+                <!-- Tagging and Commit Info -->
                 <VBox   alignment="CENTER"
                         spacing="5"
-                        GridPane.rowIndex="5"
+                        GridPane.rowIndex="4"
                         GridPane.columnIndex="6"
-                        GridPane.halignment="CENTER">
+                        GridPane.rowSpan="2"
+                        GridPane.halignment="CENTER"
+                        fx:id="infoTagBox">
+                    <fx:include source="CommitInfoView.fxml" fx:id="commitInfo"/>
                     <HBox>
                         <ArrowButton id="codeButton"
                                      fx:id="tagButton"


### PR DESCRIPTION
Fixes the layout bug for the commit info window where ref labels can't be clicked if they're under it.