### PR TITLE
Fix #523

### DIFF
--- a/src/main/java/elegit/treefx/CellLabel.java
+++ b/src/main/java/elegit/treefx/CellLabel.java
@@ -118,7 +118,7 @@ public class CellLabel extends HBox {
      * @param isRemote whether or not the ref label is remote
      */
     void setRemote(boolean isRemote) {
-        this.isRemote = true;
+        this.isRemote = isRemote;
         refreshIcon();
     }
 
@@ -163,17 +163,18 @@ public class CellLabel extends HBox {
     }
 
     /**
-     * Refreshes the icon based on various boolean values
+     * Refreshes the icon based on whether the cell is a tag, a remote branch label, or a local branch label
      */
     private void refreshIcon() {
         String image = "elegit/images/";
         if (isTag) {
             image += "tag.png";
+        } else if (isRemote && isCurrent) {
+            image += "remote_white.png";
+        } else if (isRemote) {
+            image += "remote.png";
         } else if (isCurrent) {
-            if (isRemote)
-                image += "remote_white.png";
-            else
-                image += "remote.png";
+            image += "branch_white.png";
         } else {
             image += "branch.png";
         }


### PR DESCRIPTION
I think it is important to leave the icons in because the name of the branch itself is not enough to tell whether a branch is remote or local. For example: `git checkout -b origin/fake-remote-branch` creates a valid local branch. Follow this with:
```
git checkout -b real-remote-branch
git push --set-upstream origin real-remote-branch
```
and you have two branches that both seem like they are remote but aren't. But now Elegit can tell you!
<img width="513" alt="screen shot 2017-10-05 at 10 25 34 pm" src="https://user-images.githubusercontent.com/12344924/31260463-1fdf1a3c-aa1c-11e7-88dc-cba7b7d1253e.png">
